### PR TITLE
Fix: Display jargon cards in two-column grid on wider screens

### DIFF
--- a/src/frontend/src/pages/DocumentDetailsPage.tsx
+++ b/src/frontend/src/pages/DocumentDetailsPage.tsx
@@ -269,7 +269,7 @@ export default function DocumentDetailsPage({ user, onLogout }: DocumentDetailsP
                   </p>
 
                   {flaggedTerms.length > 0 ? (
-                    <div className="mt-4 space-y-4">
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                       {flaggedTerms.map((item, i) => (
                         <div
                           key={i}


### PR DESCRIPTION
- Updated layout to use responsive grid
- Displays jargon cards in 2 columns on screens >= 768px
- Maintains single column layout for smaller screens